### PR TITLE
chore: add lefthook for code quality enforcement via git hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,12 @@
+pre-push:
+  commands:
+    check:
+      run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+    test:
+      run: npm test
+
+pre-commit:
+  commands:
+    check:
+      run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      stage_fixed: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vitest/coverage-istanbul": "^3.0.1",
         "eventemitter3": "^5.0.1",
         "fast-equals": "^5.0.1",
+        "lefthook": "^1.12.2",
         "typescript": "^5.5.4"
       },
       "peerDependencies": {
@@ -2371,6 +2372,169 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lefthook": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-1.12.2.tgz",
+      "integrity": "sha512-2CeTu5NcmoT9YnqsHTq/TF36MlqlzHzhivGx3DrXHwcff4TdvrkIwUTA56huM3Nlo5ODAF/0hlPzaKLmNHCBnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "lefthook": "bin/index.js"
+      },
+      "optionalDependencies": {
+        "lefthook-darwin-arm64": "1.12.2",
+        "lefthook-darwin-x64": "1.12.2",
+        "lefthook-freebsd-arm64": "1.12.2",
+        "lefthook-freebsd-x64": "1.12.2",
+        "lefthook-linux-arm64": "1.12.2",
+        "lefthook-linux-x64": "1.12.2",
+        "lefthook-openbsd-arm64": "1.12.2",
+        "lefthook-openbsd-x64": "1.12.2",
+        "lefthook-windows-arm64": "1.12.2",
+        "lefthook-windows-x64": "1.12.2"
+      }
+    },
+    "node_modules/lefthook-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-arm64/-/lefthook-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-fTxeI9tEskrHjc3QyEO+AG7impBXY2Ed8V5aiRc3fw9POfYtVh9b5jRx90fjk2+ld5hf+Z1DsyyLq/vOHDFskQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-darwin-x64/-/lefthook-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-T1dCDKAAfdHgYZ8qtrS02SJSHoR52RFcrGArFNll9Mu4ZSV19Sp8BO+kTwDUOcLYdcPGNaqOp9PkRBQGZWQC7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lefthook-freebsd-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-arm64/-/lefthook-freebsd-arm64-1.12.2.tgz",
+      "integrity": "sha512-2n9z7Q4BKeMBoB9cuEdv0UBQH82Z4GgBQpCrfjCtyzpDnYQwrH8Tkrlnlko4qPh9MM6nLLGIYMKsA5nltzo8Cg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-freebsd-x64/-/lefthook-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-1hNY/irY+/3kjRzKoJYxG+m3BYI8QxopJUK1PQnknGo1Wy5u302SdX+tR7pnpz6JM5chrNw4ozSbKKOvdZ5VEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/lefthook-linux-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-arm64/-/lefthook-linux-arm64-1.12.2.tgz",
+      "integrity": "sha512-1W4swYIVRkxq/LFTuuK4oVpd6NtTKY4E3VY2Uq2JDkIOJV46+8qGBF+C/QA9K3O9chLffgN7c+i+NhIuGiZ/Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-linux-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-linux-x64/-/lefthook-linux-x64-1.12.2.tgz",
+      "integrity": "sha512-J6VGuMfhq5iCsg1Pv7xULbuXC63gP5LaikT0PhkyBNMi3HQneZFDJ8k/sp0Ue9HkQv6QfWIo3/FgB9gz38MCFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lefthook-openbsd-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-arm64/-/lefthook-openbsd-arm64-1.12.2.tgz",
+      "integrity": "sha512-wncDRW3ml24DaOyH22KINumjvCohswbQqbxyH2GORRCykSnE859cTjOrRIchTKBIARF7PSeGPUtS7EK0+oDbaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-openbsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-openbsd-x64/-/lefthook-openbsd-x64-1.12.2.tgz",
+      "integrity": "sha512-2jDOkCHNnc/oK/vR62hAf3vZb1EQ6Md2GjIlgZ/V7A3ztOsM8QZ5IxwYN3D1UOIR5ZnwMBy7PtmTJC/HJrig5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/lefthook-windows-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-arm64/-/lefthook-windows-arm64-1.12.2.tgz",
+      "integrity": "sha512-ZMH/q6UNSidhHEG/1QoqIl1n4yPTBWuVmKx5bONtKHicoz4QCQ+QEiNjKsG5OO4C62nfyHGThmweCzZVUQECJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lefthook-windows-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/lefthook-windows-x64/-/lefthook-windows-x64-1.12.2.tgz",
+      "integrity": "sha512-TqT2jIPcTQ9uwaw+v+DTmvnUHM/p7bbsSrPoPX+fRXSGLzFjyiY+12C9dObSwfCQq6rT70xqQJ9AmftJQsa5/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/loupe": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vitest/coverage-istanbul": "^3.0.1",
     "eventemitter3": "^5.0.1",
     "fast-equals": "^5.0.1",
+    "lefthook": "^1.12.2",
     "typescript": "^5.5.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
Introduce lefthook to enforce code quality standards automatically through git hooks, ensuring consistent code quality across all commits and pushes.

## Changes Made
### Git Hook Configuration
- **lefthook.yml**: Configure pre-commit and pre-push hooks
  - Pre-commit: Run biome check on staged files with automatic fixing
  - Pre-push: Run biome check on push files and execute test suite
- **package.json**: Add lefthook as dev dependency
- **package-lock.json**: Update lockfile with lefthook dependencies

### Hook Details
#### Pre-commit Hook
- Runs `biome check` on staged files only
- Automatically stages fixed files (`stage_fixed: true`)
- Prevents commits with linting issues

#### Pre-push Hook  
- Runs `biome check` on files being pushed
- Executes full test suite with `npm test`
- Prevents pushes if quality checks fail

## Benefits
- **Automated Quality**: No manual linting required
- **Early Detection**: Issues caught before they reach remote
- **Consistent Standards**: All contributors follow same quality rules
- **CI/CD Efficiency**: Fewer failed builds due to quality issues

## Test plan
- [x] Verify lefthook installation and hook registration
- [x] Test pre-commit hook triggers on staged changes
- [x] Test pre-push hook runs biome check and tests
- [x] Confirm all existing tests pass (44/44 ✅)
- [x] Validate biome check passes on current codebase

🤖 Generated with [Claude Code](https://claude.ai/code)