### PR TITLE
docs: improve type casting documentation in edge case tests

### DIFF
--- a/__tests__/AtomContainer.spec.ts
+++ b/__tests__/AtomContainer.spec.ts
@@ -101,6 +101,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       }).toThrow(SyntaxError);
 
       // Incompatible data types should be accepted (type coercion)
+      // Testing runtime behavior with incompatible types
       container.fromObject({
         atom1: "string instead of number",
         nonExistentProperty: "ignored",
@@ -174,6 +175,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       const originalAtom2Value = container.atom2.value;
 
       // Only provide data for atom1
+      // Testing partial data loading with missing properties
       container.load({ atom1: 999 } as unknown as {
         atom1: number;
         atom2: number;


### PR DESCRIPTION
## Summary
- Add explanatory comments for `as unknown as` type casts in AtomContainer tests
- Clarify the intentional use of type casting for edge case testing scenarios
- Document the purpose of bypassing type safety for runtime behavior verification

## Changes
- Added comment "Testing runtime behavior with incompatible types" for the first type cast
- Added comment "Testing partial data loading with missing properties" for the second type cast

## Rationale
The `as unknown as` type casts in these tests are necessary and appropriate because:
- They test edge cases where incompatible data types are provided to verify error handling
- They simulate real-world scenarios where data might come from unreliable sources
- They verify type coercion behavior and partial data loading functionality
- The casts are contained within test files and do not affect production code

## Test Plan
- [x] All existing tests continue to pass (116/116 tests passing)
- [x] Biome linting passes without issues
- [x] Pre-commit and pre-push hooks validate successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comments to clarify the intent of specific test cases in the test suite for improved readability and understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->