### PR TITLE
Add local-notes/ directory for development memos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ esm
 # Temporary JSDoc examples directory
 temp-jsdoc-examples/
 **/settings.local.json
+
+# Local development notes and memos (not tracked in git)
+local-notes/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,10 @@ Uses Biome for linting and formatting (2-space indentation, double quotes, 80 ch
 - Event propagation flows upward through container hierarchy
 - Serialization skips atoms/containers with `isSkipSerialization: true`
 - History feature requires `useHistory: true` in container options
+
+## Project Structure
+
+### Local Development Files
+- **`local-notes/`**: Directory for local development memos and notes (excluded from git)
+  - Contains implementation considerations, debugging notes, and temporary documentation
+  - Files in this directory are not tracked in version control


### PR DESCRIPTION
## Summary
- Create `local-notes/` directory for local development memos and notes
- Add directory to `.gitignore` to exclude from version control
- Document the directory purpose in CLAUDE.md

## Changes
- Add `local-notes/` to `.gitignore`
- Move `implementation-considerations.md` to `local-notes/`
- Create `local-notes/README.md` explaining directory usage
- Update CLAUDE.md with project structure documentation

## Benefits
- Allows developers to keep local development notes without tracking in git
- Provides clear separation between shared code and personal memos
- Maintains clean repository while enabling local documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a section describing the purpose and usage of the local development notes directory.
* **Chores**
  * Updated the ignore list to exclude local development notes from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->