### PR TITLE
feat: rename init() method to connectMemberAtoms() for improved clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Uses Biome for linting and formatting (2-space indentation, double quotes, 80 ch
 - Declaration files generated with source maps
 
 ### Architecture Notes
-- All atoms must call `init()` in AtomContainer constructors after adding member atoms
+- All atoms must call `connectMemberAtoms()` in AtomContainer constructors after adding member atoms
 - Event propagation flows upward through container hierarchy
 - Serialization skips atoms/containers with `isSkipSerialization: true`
 - History feature requires `useHistory: true` in container options

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ class AppContainer extends AtomContainer<AppState> {
 
   constructor() {
     super();
-    this.init(); // Required after adding member atoms
+    this.connectMemberAtoms(); // Required after adding member atoms
   }
 }
 ```
@@ -154,7 +154,7 @@ class HistoryContainer extends AtomContainer<{ count: number }> {
 
   constructor() {
     super({ useHistory: true }); // Enable history tracking
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 
@@ -208,7 +208,7 @@ class AppContainerWithRuntimeState extends AtomContainer<{
 
   constructor() {
     super({ useHistory: true });
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 ```
@@ -270,7 +270,7 @@ class MyContainer extends AtomContainer<{ count: number; active: boolean }> {
   
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
     
     // Pattern 1: Explicit type specification
     this.on("change", (args: AtomEventArgs<number>) => {

--- a/__tests__/AtomContainer.Event.spec.ts
+++ b/__tests__/AtomContainer.Event.spec.ts
@@ -21,7 +21,7 @@ export class ExtendEventContainer extends AtomContainer<
   readonly atom2 = new Atom(2);
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 

--- a/__tests__/AtomContainer.EventOrder.spec.ts
+++ b/__tests__/AtomContainer.EventOrder.spec.ts
@@ -14,7 +14,7 @@ export class SimpleAtomContainer extends AtomContainer {
   readonly atom2 = new Atom(2);
   constructor(options?: AtomContainerOptions) {
     super(options);
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 
@@ -46,7 +46,7 @@ describe("AtomContainer - Event Propagation Order Specification", () => {
       child = new SimpleAtomContainer();
       constructor() {
         super();
-        this.init();
+        this.connectMemberAtoms();
       }
     }
 
@@ -77,7 +77,7 @@ describe("AtomContainer - Event Propagation Order Specification", () => {
 
       constructor() {
         super();
-        this.init();
+        this.connectMemberAtoms();
       }
     }
 
@@ -129,7 +129,7 @@ describe("AtomContainer - Event Propagation Order Specification", () => {
 
       constructor() {
         super();
-        this.init();
+        this.connectMemberAtoms();
       }
     }
 
@@ -200,7 +200,7 @@ describe("AtomContainer - Event Propagation Order Specification", () => {
 
       constructor() {
         super();
-        this.init();
+        this.connectMemberAtoms();
       }
     }
 
@@ -234,7 +234,7 @@ describe("AtomContainer - Event Propagation Order Specification", () => {
 
       constructor() {
         super();
-        this.init();
+        this.connectMemberAtoms();
       }
     }
 

--- a/__tests__/AtomContainer.compatibility.spec.ts
+++ b/__tests__/AtomContainer.compatibility.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { Atom, AtomContainer } from "../src/index.js";
+
+// Type for accessing protected init() method in tests
+interface AtomContainerWithInit {
+  init(): void;
+}
+
+// Combined type for testing both methods
+type TestableAtomContainer = AtomContainer & AtomContainerWithInit;
+
+/**
+ * Test helper class using the new connectMemberAtoms() method.
+ */
+class NewMethodContainer extends AtomContainer {
+  readonly atom1 = new Atom(1);
+  readonly atom2 = new Atom(2);
+
+  constructor() {
+    super();
+    this.connectMemberAtoms();
+  }
+}
+
+/**
+ * Test helper class using the legacy init() method.
+ */
+class LegacyMethodContainer extends AtomContainer {
+  readonly atom1 = new Atom(1);
+  readonly atom2 = new Atom(2);
+
+  constructor() {
+    super();
+    // TypeScript should still allow calling the protected init() method from within the class
+    this.init();
+  }
+}
+
+describe("AtomContainer.compatibility - Backward compatibility between init() and connectMemberAtoms()", () => {
+  it("should have both init() and connectMemberAtoms() methods available", () => {
+    const container = new AtomContainer();
+
+    // Check that both methods exist
+    expect(typeof container.connectMemberAtoms).toBe("function");
+    expect(typeof (container as TestableAtomContainer).init).toBe("function");
+  });
+
+  it("should produce identical behavior between init() and connectMemberAtoms()", () => {
+    const newMethodContainer = new NewMethodContainer();
+    const legacyContainer = new LegacyMethodContainer();
+
+    // Both containers should have the same initialization state
+    expect(newMethodContainer.toObject()).toEqual(legacyContainer.toObject());
+
+    // Event propagation should work identically
+    const newMethodSpy = vi.fn();
+    const legacySpy = vi.fn();
+
+    newMethodContainer.on("change", newMethodSpy);
+    legacyContainer.on("change", legacySpy);
+
+    // Change values and verify both containers propagate events
+    newMethodContainer.atom1.value = 10;
+    legacyContainer.atom1.value = 10;
+
+    expect(newMethodSpy).toHaveBeenCalledTimes(1);
+    expect(legacySpy).toHaveBeenCalledTimes(1);
+
+    // Event arguments should be identical structure
+    expect(newMethodSpy.mock.calls[0][0]).toMatchObject({
+      from: newMethodContainer.atom1,
+      value: 10,
+      valueFrom: 1,
+    });
+    expect(legacySpy.mock.calls[0][0]).toMatchObject({
+      from: legacyContainer.atom1,
+      value: 10,
+      valueFrom: 1,
+    });
+  });
+
+  it("should allow multiple calls to both methods without side effects", () => {
+    const container = new AtomContainer();
+    container.connectMemberAtoms();
+    container.connectMemberAtoms();
+    (container as TestableAtomContainer).init();
+    (container as TestableAtomContainer).init();
+
+    // Multiple calls should not cause errors or duplicate listeners
+    expect(container).toBeTruthy();
+  });
+
+  it("should maintain idempotency across method calls", () => {
+    class TestContainer extends AtomContainer {
+      readonly atom = new Atom(1);
+
+      constructor() {
+        super();
+        // Mix of both methods
+        this.connectMemberAtoms();
+        this.init();
+        this.connectMemberAtoms();
+      }
+    }
+
+    const container = new TestContainer();
+    const spy = vi.fn();
+    container.on("change", spy);
+
+    container.atom.value = 2;
+
+    // Should only fire once despite multiple initialization calls
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show deprecation in JSDoc but still function correctly", () => {
+    const container = new AtomContainer();
+
+    // The init method should still work for backward compatibility
+    expect(() => {
+      (container as TestableAtomContainer).init();
+    }).not.toThrow();
+  });
+});

--- a/__tests__/AtomContainer.console-warn.spec.ts
+++ b/__tests__/AtomContainer.console-warn.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Atom, AtomContainer } from "../src/index.js";
 
 /**
- * Test container that intentionally does NOT call init() in constructor.
+ * Test container that intentionally does NOT call connectMemberAtoms() in constructor.
  * Used to verify warning behavior when operations are called before initialization.
  */
 class UninitializedContainer extends AtomContainer<{
@@ -16,7 +16,7 @@ class UninitializedContainer extends AtomContainer<{
     super();
     this.nameAtom = new Atom(data.name);
     this.ageAtom = new Atom(data.age);
-    // NOTE: Intentionally NOT calling this.init() to test warning behavior
+    // NOTE: Intentionally NOT calling this.connectMemberAtoms() to test warning behavior
   }
 
   get name() {
@@ -35,7 +35,7 @@ class UninitializedContainer extends AtomContainer<{
 }
 
 /**
- * Test container that properly calls init() in constructor.
+ * Test container that properly calls connectMemberAtoms() in constructor.
  * Used as control group to verify no warnings when properly initialized.
  */
 class ProperlyInitializedContainer extends AtomContainer<{ value: number }> {
@@ -44,7 +44,7 @@ class ProperlyInitializedContainer extends AtomContainer<{ value: number }> {
   constructor(initialValue: number, options?: { useHistory?: boolean }) {
     super(options);
     this.valueAtom = new Atom(initialValue);
-    this.init(); // Properly calling init()
+    this.connectMemberAtoms(); // Properly calling connectMemberAtoms()
   }
 
   get value() {
@@ -67,9 +67,9 @@ const expectWarningMessage = (
   methodName: string,
 ) => {
   expect(consoleSpy).toHaveBeenCalledWith(
-    `UninitializedContainer.${methodName}() was called before init(). ` +
+    `UninitializedContainer.${methodName}() was called before connectMemberAtoms(). ` +
       "This may cause event system failures. " +
-      "Ensure you call this.init() in your constructor after adding member atoms.",
+      "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
   );
 };
 
@@ -152,15 +152,15 @@ describe("AtomContainer - Console.warn Validation", () => {
       expect(consoleSpy).toHaveBeenCalledTimes(2);
       expect(consoleSpy).toHaveBeenNthCalledWith(
         1,
-        "UninitializedContainer.fromObject() was called before init(). " +
+        "UninitializedContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
         2,
-        "UninitializedContainer.addHistory() was called before init(). " +
+        "UninitializedContainer.addHistory() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -290,9 +290,9 @@ describe("AtomContainer - Console.warn Validation", () => {
       container.fromObject({ test: "updated" });
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "CustomNamedContainer.fromObject() was called before init(). " +
+        "CustomNamedContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();

--- a/__tests__/AtomContainer.skip.spec.ts
+++ b/__tests__/AtomContainer.skip.spec.ts
@@ -14,7 +14,7 @@ export class SkipAtomContainer extends AtomContainer {
   });
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 
@@ -30,7 +30,7 @@ export class NewSkipAtomContainer extends AtomContainer {
   });
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 
@@ -44,7 +44,7 @@ export class CompatibilityTestContainer extends AtomContainer {
   readonly atomNew = new Atom(3, { skipSerialization: true });
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 

--- a/__tests__/AtomContainer.spec.ts
+++ b/__tests__/AtomContainer.spec.ts
@@ -14,7 +14,7 @@ export class SimpleAtomContainer extends AtomContainer {
   readonly atom2 = new Atom(2);
   constructor(options?: AtomContainerOptions) {
     super(options);
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 
@@ -120,7 +120,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       class EmptyContainer extends AtomContainer {
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -140,7 +140,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
 
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -194,7 +194,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
         atom = new Atom("level3");
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -203,7 +203,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
         nested = new Level3Container();
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -212,7 +212,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
         nested = new Level2Container();
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -248,7 +248,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
 
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -284,7 +284,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
 
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -319,7 +319,7 @@ describe("AtomContainer - Hierarchical state management with event propagation a
 
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
       }
 
@@ -335,20 +335,20 @@ describe("AtomContainer - Hierarchical state management with event propagation a
     });
   });
 
-  describe("init() method idempotency", () => {
-    it("should allow multiple init() calls without breaking event listeners", () => {
+  describe("connectMemberAtoms() method idempotency", () => {
+    it("should allow multiple connectMemberAtoms() calls without breaking event listeners", () => {
       class TestContainer extends AtomContainer {
         atom1 = new Atom(1);
         atom2 = new Atom(2);
 
         constructor() {
           super();
-          this.init(); // First call (required)
+          this.connectMemberAtoms(); // First call (required)
         }
 
         // Public method to test multiple init calls
-        public reinit() {
-          this.init();
+        public reconnectMemberAtoms() {
+          this.connectMemberAtoms();
         }
       }
 
@@ -360,10 +360,10 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       container.on("beforeChange", spyBeforeChange);
       container.on("change", spyChange);
 
-      // Call init() multiple times
-      container.reinit();
-      container.reinit();
-      container.reinit();
+      // Call connectMemberAtoms() multiple times
+      container.reconnectMemberAtoms();
+      container.reconnectMemberAtoms();
+      container.reconnectMemberAtoms();
 
       // Change atom value to trigger events
       container.atom1.value = 10;
@@ -385,28 +385,28 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       });
     });
 
-    it("should not duplicate listeners when init() is called multiple times", () => {
+    it("should not duplicate listeners when connectMemberAtoms() is called multiple times", () => {
       class TestContainer extends AtomContainer {
         atom1 = new Atom(1);
 
         constructor() {
           super();
-          this.init();
+          this.connectMemberAtoms();
         }
 
-        public reinit() {
-          this.init();
+        public reconnectMemberAtoms() {
+          this.connectMemberAtoms();
         }
       }
 
       const container = new TestContainer();
 
-      // After first init(), there should be exactly 1 change listener from container
+      // After first connectMemberAtoms(), there should be exactly 1 change listener from container
       expect(container.atom1.listenerCount("change")).toBe(1);
 
       // Call init multiple times
-      container.reinit();
-      container.reinit();
+      container.reconnectMemberAtoms();
+      container.reconnectMemberAtoms();
 
       // Listener count should remain exactly 1
       expect(container.atom1.listenerCount("change")).toBe(1);
@@ -418,11 +418,11 @@ describe("AtomContainer - Hierarchical state management with event propagation a
 
         constructor() {
           super({ useHistory: true });
-          this.init();
+          this.connectMemberAtoms();
         }
 
-        public reinit() {
-          this.init();
+        public reconnectMemberAtoms() {
+          this.connectMemberAtoms();
         }
       }
 
@@ -432,14 +432,14 @@ describe("AtomContainer - Hierarchical state management with event propagation a
       // Monitor addHistory events
       container.on("addHistory", spyAddHistory);
 
-      // After init() with useHistory:true, there should be exactly 2 listeners:
+      // After connectMemberAtoms() with useHistory:true, there should be exactly 2 listeners:
       // 1. Internal history listener from initHistory()
       // 2. Test spy listener we just added
       expect(container.listenerCount("addHistory")).toBe(2);
 
       // Call init multiple times
-      container.reinit();
-      container.reinit();
+      container.reconnectMemberAtoms();
+      container.reconnectMemberAtoms();
 
       // History listener count should remain exactly 2
       expect(container.listenerCount("addHistory")).toBe(2);

--- a/__tests__/InitValidationHelper.spec.ts
+++ b/__tests__/InitValidationHelper.spec.ts
@@ -36,9 +36,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("fromObject");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "TestContainer.fromObject() was called before init(). " +
+        "TestContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -66,9 +66,9 @@ describe("InitValidationHelper", () => {
 
       expect(consoleSpy).toHaveBeenCalledTimes(1);
       expect(consoleSpy).toHaveBeenCalledWith(
-        "TestContainer.fromObject() was called before init(). " +
+        "TestContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -81,9 +81,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("addHistory");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "UserContainer.addHistory() was called before init(). " +
+        "UserContainer.addHistory() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -96,9 +96,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("fromObject");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "CustomContainer.fromObject() was called before init(). " +
+        "CustomContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -111,9 +111,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("fromObject");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "AtomContainer.fromObject() was called before init(). " +
+        "AtomContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -165,9 +165,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("fromObject");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        ".fromObject() was called before init(). " +
+        ".fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -180,9 +180,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("fromObject");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Special$Container_123.fromObject() was called before init(). " +
+        "Special$Container_123.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -210,9 +210,9 @@ describe("InitValidationHelper", () => {
 
       expect(consoleSpy).toHaveBeenCalledTimes(1);
       expect(consoleSpy).toHaveBeenCalledWith(
-        "TestContainer.fromObject() was called before init(). " +
+        "TestContainer.fromObject() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();
@@ -225,9 +225,9 @@ describe("InitValidationHelper", () => {
       helper.validateInitialized("");
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "TestContainer.() was called before init(). " +
+        "TestContainer.() was called before connectMemberAtoms(). " +
           "This may cause event system failures. " +
-          "Ensure you call this.init() in your constructor after adding member atoms.",
+          "Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.",
       );
 
       consoleSpy.mockRestore();

--- a/__tests__/MultipleAtomContainer.spec.ts
+++ b/__tests__/MultipleAtomContainer.spec.ts
@@ -12,7 +12,7 @@ export class MultipleAtomContainer extends AtomContainer {
   readonly atomContainer = new SimpleAtomContainer();
   constructor() {
     super();
-    this.init();
+    this.connectMemberAtoms();
   }
 }
 

--- a/src/utils/InitValidationHelper.ts
+++ b/src/utils/InitValidationHelper.ts
@@ -1,8 +1,8 @@
 /**
  * Helper class for managing AtomContainer initialization validation and warnings.
  *
- * This class tracks whether an AtomContainer has been properly initialized via init()
- * and provides helpful developer warnings when operations are called before initialization.
+ * This class tracks whether an AtomContainer has been properly initialized via connectMemberAtoms()
+ * (or the legacy init() method) and provides helpful developer warnings when operations are called before initialization.
  * It implements smart warning deduplication to prevent console spam while still providing
  * useful debugging information.
  *
@@ -11,9 +11,9 @@
  * class MyContainer extends AtomContainer {
  *   private _validator = new InitValidationHelper('MyContainer');
  *
- *   protected init() {
+ *   public connectMemberAtoms() {
  *     this._validator.markInitialized();
- *     super.init();
+ *     super.connectMemberAtoms();
  *   }
  *
  *   someOperation() {
@@ -27,7 +27,7 @@
  */
 export class InitValidationHelper {
   /**
-   * Whether the container has been properly initialized via init().
+   * Whether the container has been properly initialized via connectMemberAtoms() or init().
    */
   private _isInitialized = false;
 
@@ -56,12 +56,12 @@ export class InitValidationHelper {
   /**
    * Mark the container as properly initialized.
    *
-   * This should be called from the container's init() method to indicate
+   * This should be called from the container's connectMemberAtoms() method to indicate
    * that initialization is complete and operations can safely proceed.
    *
    * @example
    * ```typescript
-   * protected init() {
+   * public connectMemberAtoms() {
    *   this._initValidator.markInitialized();
    *   this.addMembers();
    *   this.initHistory();
@@ -73,7 +73,7 @@ export class InitValidationHelper {
   }
 
   /**
-   * Check if init() has been called and warn if not.
+   * Check if connectMemberAtoms() has been called and warn if not.
    *
    * This method should be called at the beginning of operations that require
    * proper initialization (like fromObject, addHistory, etc.). It will show
@@ -93,9 +93,9 @@ export class InitValidationHelper {
   validateInitialized(operationName: string): void {
     if (!this._isInitialized && !this._hasWarned) {
       console.warn(
-        `${this._containerName}.${operationName}() was called before init(). ` +
+        `${this._containerName}.${operationName}() was called before connectMemberAtoms(). ` +
           `This may cause event system failures. ` +
-          `Ensure you call this.init() in your constructor after adding member atoms.`,
+          `Ensure you call this.connectMemberAtoms() in your constructor after adding member atoms.`,
       );
       this._hasWarned = true;
     }


### PR DESCRIPTION
## Summary
- Add new `connectMemberAtoms()` public method with clear, descriptive naming  
- Keep `init()` as deprecated alias for backward compatibility
- Update all tests, documentation, and examples to use new method name
- Add comprehensive compatibility tests to ensure seamless transition

## Motivation
The method name `init()` was ambiguous and caused developer confusion about what exactly was being initialized. The new name `connectMemberAtoms()` clearly indicates that this method discovers member atoms/containers and connects them to the event bubbling system.

## Changes Made
- **New Method**: `connectMemberAtoms()` - public method with clear JSDoc documentation
- **Backward Compatibility**: `init()` method retained as `@deprecated` wrapper with detailed background information
- **Test Updates**: All test files updated to use new method name (175 tests pass)
- **Documentation**: README.md, CLAUDE.md, and JSDoc comments updated with new examples
- **Compatibility Testing**: New test suite ensuring both methods work identically

## Breaking Changes
**None** - This is a backward-compatible enhancement. The `init()` method continues to work with deprecation warnings.

## Migration Path
```typescript
// Old (still works, but deprecated)
class MyContainer extends AtomContainer {
  constructor() {
    super();
    this.init(); // Works but shows deprecation warning
  }
}

// New (recommended)
class MyContainer extends AtomContainer {
  constructor() {
    super();
    this.connectMemberAtoms(); // Clear and descriptive
  }
}
```

## Test Results
- ✅ **175 tests** pass (including 5 new compatibility tests)
- ✅ **Biome** linting and formatting checks pass
- ✅ **Pre-commit/pre-push** hooks pass
- ✅ **No functionality regression** confirmed

## Future Plans
The deprecated `init()` method will be removed in v1.0.0, providing sufficient time for users to migrate to the new, clearer method name.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references in documentation to use the new `connectMemberAtoms()` method instead of `init()` for initializing containers.
  * Clarified usage and migration details regarding the method name change.

* **New Features**
  * Introduced a new public method, `connectMemberAtoms()`, for container initialization.

* **Refactor**
  * Replaced calls to `init()` with `connectMemberAtoms()` across all test suites and internal logic.
  * Deprecated the `init()` method, retaining it as a protected alias for backward compatibility.

* **Tests**
  * Added and updated tests to verify compatibility and correct behavior of the new initialization method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->