### PR TITLE
Migrate to npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -2,6 +2,11 @@ name: Publish to NPM
 on:
   release:
     types: [published]
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read   # Required for repository access
+
 jobs:
   npm-publish:
     runs-on: ubuntu-22.04
@@ -14,10 +19,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
       - run: npm ci
       - name: build binary
         run: npm run build
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary
- Implement OpenID Connect (OIDC) authentication for secure npm publishing
- Remove dependency on long-lived NPM_PUBLISH_TOKEN for enhanced security  
- Add automatic npm version upgrade to ensure trusted publishing compatibility

## Changes
- Add OIDC permissions (`id-token: write`, `contents: read`) to workflow
- Remove `NODE_AUTH_TOKEN` environment variable and secrets dependency
- Upgrade npm to latest version before publishing to support trusted publishing features
- Maintain existing workflow trigger and publishing behavior

## Security Benefits
- Eliminates long-lived token storage in GitHub secrets
- Uses short-lived, workflow-specific authentication credentials
- Automatic provenance attestation generation
- Cryptographic trust relationship between repository and npm registry

## Testing Plan
- [ ] Verify trusted publisher configuration on npmjs.com matches repository settings
- [ ] Test with pre-release version to confirm OIDC authentication works
- [ ] Validate provenance attestations are generated correctly
- [ ] Remove old NPM_PUBLISH_TOKEN secret after successful migration

## Prerequisites
✅ Trusted publisher configured on npmjs.com for masatomakino/StateAtoms
✅ Workflow filename matches exactly: npm_publish.yml

🤖 Generated with [Claude Code](https://claude.ai/code)