### PR TITLE
security: pin third-party GitHub Action to commit SHA

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Report Coverage
         if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@8ab049ff5a2c6e78f78af446329379b318544a1a # v2.8.3


### PR DESCRIPTION
## Summary
Pin `davelosert/vitest-coverage-report-action` from mutable tag `@v2` to immutable commit SHA to mitigate supply chain attack risks.

## Changes
- Pin `davelosert/vitest-coverage-report-action@v2` → `@8ab049ff5a2c6e78f78af446329379b318544a1a # v2.8.3`

## Security Benefits
- **Immutable reference**: Prevents automatic execution of potentially compromised code from tag updates
- **Supply chain protection**: Mitigates risks from action repository compromise (e.g., tj-actions incident)
- **GitHub recommended**: Follows official security hardening guidelines

## References
- [GitHub Security Hardening Guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- Commit verified: https://github.com/davelosert/vitest-coverage-report-action/commit/8ab049ff5a2c6e78f78af446329379b318544a1a

## Test Plan
- [x] Verify workflow file syntax
- [x] Confirm commit SHA corresponds to v2.8.3 release
- [x] Validate action repository authenticity (not a fork)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the CI coverage reporting action to a specific commit to ensure consistent, reproducible coverage reports in the pipeline.
  * Improves reliability of coverage summaries shown on pull requests.
  * No changes to application features, behavior, or configuration for end-users.
  * No impact on performance, UI, compatibility, or installation/upgrade flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->