### PR TITLE
ci: update GitHub Actions dependency check to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     cooldown:
       default-days: 5
 


### PR DESCRIPTION
## Summary
Update Dependabot configuration to check for GitHub Actions updates weekly instead of monthly for more timely security updates.

## Changes
- Change GitHub Actions update interval: `monthly` → `weekly`
- Maintain npm dependency check at `daily` (unchanged)

## Benefits
- **Faster security updates**: Weekly checks ensure SHA-pinned actions get updated promptly
- **Improved maintenance**: More frequent detection of new action releases
- **Security posture**: Reduces window of exposure to potential vulnerabilities
- **Rate limiting protection**: Existing 5-day cooldown period prevents excessive PRs

## Configuration Details
```yaml
# Before
schedule:
  interval: "monthly"

# After  
schedule:
  interval: "weekly"
  cooldown:
    default-days: 5  # Existing cooldown allows safe frequency increase
```

## Related
- Complements recent SHA pinning improvements (#109)
- Ensures pinned actions stay current with security updates
- Cooldown period prevents spam while enabling responsive updates

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automated dependency update cadence: GitHub Actions dependencies are now checked weekly (previously monthly); npm checks remain daily.
  * Improves timeliness of maintenance updates and security patches, reducing risk from outdated CI workflows.
  * Expect slightly more frequent bot PRs; no functional or UI changes for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->