### PR TITLE
ci: add Node.js v24 to CI workflow matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
## Summary
- Add Node.js v24 to the CI workflow matrix for compatibility testing

## Changes
- Updated `.github/workflows/ci.yml` to include Node.js 24.x in the test matrix
- CI will now test against Node.js 20.x, 22.x, and 24.x

## Test plan
- [x] All existing tests pass with Node.js 24.x
- [x] Pre-push validation completed successfully
- [ ] CI workflow runs successfully with all three Node.js versions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to include testing on Node.js 24, broadening environment coverage and improving release confidence.
* **Tests**
  * Expanded runtime test matrix to cover Node.js 24 alongside existing versions for better cross-version stability verification.
* **Note**
  * No user-facing changes; functionality and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->