### PR TITLE
chore: add explicit minimal permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permission to CI workflow
- Follow security best practices by granting only minimum required permissions
- Remove default broad permissions that include unnecessary write access

## Changes
- Updated `.github/workflows/ci.yml` to include explicit `permissions:` section
- CI workflow only needs read access to checkout code, install dependencies, run tests and build
- Other workflows (`coverage.yml`, `npm_publish.yml`) already have appropriate permissions

## Security Impact
- Reduces attack surface by limiting CI workflow permissions
- Follows principle of least privilege
- Prevents potential security issues from CI workflow having write access

🤖 Generated with [Claude Code](https://claude.ai/code)