### PR TITLE
docs: add Agent Container section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ See **`.devcontainer/sample-hooks/README.md`** for setup instructions.
 
 ### Agent Container (Claude Code Sandbox)
 
-A separate DevContainer for autonomous Claude Code agents (e.g., conductor workers).
+A separate DevContainer for autonomous Claude Code agents (e.g., a conductor agent that orchestrates multiple worktrees in parallel).
 
 - **Config**: `.devcontainer/claude/`
 - **Image**: `node:24` (full image with Git, gh CLI, git-delta)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ All tasks use `devcontainer exec --workspace-folder .` for command execution. Us
 
 ## Development Container
 
-### Quick Reference
+### npm Isolation Container
 
 - **Image**: `node:22-bookworm-slim` (minimal Node.js 22 image, no Git)
 - **npm Isolation**: All npm commands execute exclusively in the container
@@ -63,11 +63,22 @@ All tasks use `devcontainer exec --workspace-folder .` for command execution. Us
 For detailed container architecture, security model, and configuration, see:
 - **`.devcontainer/README.md`**: Complete DevContainer documentation
 
-### Git Hooks Setup (Optional)
+#### Git Hooks Setup (Optional)
 
 Git hooks can automatically run code quality checks before commits and pushes by bridging host Git and container npm.
 
 See **`.devcontainer/sample-hooks/README.md`** for setup instructions.
+
+### Agent Container (Claude Code Sandbox)
+
+A separate DevContainer for autonomous Claude Code agents (e.g., conductor workers).
+
+- **Config**: `.devcontainer/claude/`
+- **Image**: `node:24` (full image with Git, gh CLI, git-delta)
+- **Git**: Available inside the container (unlike the development container)
+- **Includes**: Claude Code CLI, zsh, fzf, nano, vim, jq
+- **Network**: Firewall-restricted via `init-firewall.sh` (`NET_ADMIN` capability)
+- **Commands run directly** (no `devcontainer exec` needed from inside)
 
 ## Technical Details
 


### PR DESCRIPTION
## Summary

Add Agent Container (Claude Code Sandbox) documentation to CLAUDE.md, distinguishing it from the npm Isolation Container used for development.

**Scope:**

**Changes:**
- Rename "Quick Reference" to "npm Isolation Container" for clarity
- Move "Git Hooks Setup" as subsection (`####`) under npm Isolation Container
- Add new "Agent Container (Claude Code Sandbox)" section with config, image, and capabilities

**Unchanged:**
- npm Isolation Container content and `.devcontainer/README.md` reference
- Agent Container Dockerfile and configuration (`.devcontainer/claude/`)

## Test plan

- [ ] Verify CLAUDE.md heading hierarchy renders correctly on GitHub
- [ ] Confirm no content was lost from the original "Quick Reference" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the "Quick Reference" section to "npm Isolation Container" for clearer naming.
  * Added a new "Agent Container (Claude Code Sandbox)" section with configuration, image, Git availability, included tools, network notes, and how commands are run.
  * Adjusted the "Git Hooks Setup (Optional)" heading to a lower-level subheading for improved structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->